### PR TITLE
Bugfix: avoid repeatedly requesting the same split change_number

### DIFF
--- a/splitio/sync/split.py
+++ b/splitio/sync/split.py
@@ -40,6 +40,7 @@ class SplitSynchronizer(object):
         :param till: Passed till from Streaming.
         :type till: int
         """
+        fetched_changes = set()
         while True:
             change_number = self._split_storage.get_change_number()
             if change_number is None:
@@ -47,6 +48,10 @@ class SplitSynchronizer(object):
             if till is not None and till < change_number:
                 # the passed till is less than change_number, no need to perform updates
                 return
+            if change_number in fetched_changes:
+                # don't re-request a change we've already seen
+                return
+            fetched_changes.add(change_number)
 
             try:
                 split_changes = self._api.fetch_splits(change_number)


### PR DESCRIPTION
# Python SDK

## What did you accomplish?
Fixed a bug related to repeated calls to `api.fetch_splits`. This seemed to happen when a change event was generated that didn't update the `till` value of the response from the `splitChanges` REST call. Let's say the last change we fetched was t1, and there's an event at t2. In `synchronize_splits` we would first start with `split_storage.get_change_number()` and get t1 back, then re-fetch that. In normal operation, this would result in new data and an update `till` value in the response. However, we see cases in production where the till value does not advance. Since the fetched `till` value is still less than t2, [this condition](https://github.com/splitio/python-client/blob/8.4.0/splitio/sync/split.py#L65-L66) is never met, and we don't break out of the `while True` loop that starts on line 43.

## How do we test the changes introduced in this PR?
A test is included

## Extra Notes